### PR TITLE
Fix permission of /system/etc/init.d if it already exists

### DIFF
--- a/src/com/androguide/universal/init/d/Initd.java
+++ b/src/com/androguide/universal/init/d/Initd.java
@@ -129,9 +129,14 @@ public class Initd extends SherlockFragment {
 			cmd.su.runWaitFor("chmod 755 /system/etc/init.d/found");
 			cmd.su.runWaitFor("mount -o remount,ro /system");
 			cmd.su.runWaitFor("mount -o remount,ro /system");
+		} else if (!dir.canRead()) {
+
+			cmd.su.runWaitFor("mount -o remount,rw /system");
+			cmd.su.runWaitFor("chmod 755 /system/etc/init.d");
+			cmd.su.runWaitFor("mount -o remount,ro /system");
 		}
 
-		File d = new File("/system/etc/init.d");
+		File d = new File("/system/etc/init.d");		
 		File[] file = d.listFiles();
 
 		if (file.length == 0) {


### PR DESCRIPTION
Found this error on my Xperia M when the init.d directory already existed but did not have read permissions for the normal user; this caused an exception at startup because FIle.listFiles() returns null if there is an IO error.
